### PR TITLE
use https:// URL for mupdf-android-fitz in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "thirdparty/mupdf-jni"]
 	path = thirdparty/mupdf-jni
-	url = git://git.ghostscript.com/mupdf-android-fitz.git
+	url = https://git.ghostscript.com/mupdf-android-fitz.git


### PR DESCRIPTION

HTTPS Everywhere! This is a trivial fix to improve privacy and security.